### PR TITLE
migrations は翻訳せず「マイグレーション」とすべき

### DIFF
--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -65,9 +65,9 @@ dotnet new webapp --auth Individual -o WebApp1
 * /ユーザー/アカウント/ログアウト
 * /ユーザー/アカウント/管理
 
-### <a name="apply-migrations"></a>移行を適用する
+### <a name="apply-migrations"></a>マイグレーションの適用
 
-データベースを初期化するへの移行を適用します。
+データベースを初期化するためのマイグレーションを適用します。
 
 # <a name="visual-studiotabvisual-studio"></a>[Visual Studio](#tab/visual-studio)
 


### PR DESCRIPTION
日本のソフトウェア開発者にとって、特にデータベース関連での `migration` は日本語に翻訳せず `マイグレーション`とするほうが一般的です。
`移行` とするのは過度な翻訳であり、誤解が生じたり理解の妨げになる可能性が高いです。