### PR TITLE
improve translate

### DIFF
--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -59,7 +59,7 @@ dotnet new webapp --auth Individual -o WebApp1
 
 ---
 
-生成されたプロジェクトは、 [ASP.NET Core Identity](xref:security/authentication/identity)として、 [Razor クラス ライブラリ](xref:razor-pages/ui-class)します。 Id の Razor クラス ライブラリでエンドポイントを公開する、`Identity`領域。 例:
+生成されたプロジェクトは、 [ASP.NET Core Identity](xref:security/authentication/identity)を [Razor クラス ライブラリ](xref:razor-pages/ui-class)として提供します。 Identity の Razor クラス ライブラリは`Identity`エリアでエンドポイントを公開します。 例:
 
 * /Identity/Account/Login
 * /Identity/Account/Logout


### PR DESCRIPTION
- 日本語として自然な語順に修正
- Id → Identity (See : #220 )
- `領域` → `エリア`
  - Visual Studio 2010以降のIDE上でASP.NET MVCの`area`は`エリア`と翻訳されているので合わせるべき
  - ![image](https://user-images.githubusercontent.com/558604/57665033-57ce6880-7635-11e9-91a8-a82bb5b781c7.png)
