### PR TITLE
『ASP.NET Core 用の認証のサンプル』の全体的な翻訳改善

### DIFF
--- a/aspnetcore/security/authentication/samples.md
+++ b/aspnetcore/security/authentication/samples.md
@@ -16,19 +16,19 @@ ms.locfileid: "64897159"
 
 作成者: [Rick Anderson](https://twitter.com/RickAndMSFT)
 
-[ASP.NET Core リポジトリ](https://github.com/aspnet/AspNetCore)次認証サンプルを含む、 *AspNetCore/src/セキュリティ/サンプル*フォルダー。
+[ASP.NET Core リポジトリ](https://github.com/aspnet/AspNetCore)の*AspNetCore/src/Security/samples*フォルダーには次の通り認証についてのサンプルが含まれています 。
 
 * [クレームの変換](https://github.com/aspnet/AspNetCore/tree/release/2.2/src/Security/samples/ClaimsTransformation)
 * [Cookie 認証](https://github.com/aspnet/AspNetCore/tree/release/2.2/src/Security/samples/Cookies)
 * [カスタム ポリシー プロバイダー - IAuthorizationPolicyProvider](https://github.com/aspnet/AspNetCore/tree/release/2.2/src/Security/samples/CustomPolicyProvider)
 * [動的な認証スキームとオプション](https://github.com/aspnet/AspNetCore/tree/release/2.2/src/Security/samples/DynamicSchemes)
-* [外部の要求](https://github.com/aspnet/AspNetCore/tree/release/2.2/src/Security/samples/Identity.ExternalClaims)
-* [Cookie と、要求に基づいて別の認証スキームの選択](https://github.com/aspnet/AspNetCore/tree/release/2.2/src/Security/samples/PathSchemeSelection)
-* [静的ファイルへのアクセスを制限します。](https://github.com/aspnet/AspNetCore/tree/release/2.2/src/Security/samples/StaticFilesAuth)
+* [外部クレーム](https://github.com/aspnet/AspNetCore/tree/release/2.2/src/Security/samples/Identity.ExternalClaims)
+* [要求に基づくCookieと別の認証スキームの選択](https://github.com/aspnet/AspNetCore/tree/release/2.2/src/Security/samples/PathSchemeSelection)
+* [静的ファイルへのアクセス制限](https://github.com/aspnet/AspNetCore/tree/release/2.2/src/Security/samples/StaticFilesAuth)
 
-## <a name="run-the-samples"></a>サンプルを実行します。
+## <a name="run-the-samples"></a>サンプルの実行
 
-* 選択、[ブランチ](https://github.com/aspnet/AspNetCore)します。 たとえば、`release/2.2`
-* 複製またはダウンロード、 [ASP.NET Core リポジトリ](https://github.com/aspnet/AspNetCore)します。
-* インストールされていることを確認、 [.NET Core SDK](https://www.microsoft.com/net/download/all) ASP.NET Core リポジトリの複製に一致するバージョン。
-* サンプルに移動します*AspNetCore/src/セキュリティ/サンプル*、サンプルを実行および`dotnet run`します。
+* [ブランチ](https://github.com/aspnet/AspNetCore)を選択します。 例、`release/2.2`
+* [ASP.NET Core リポジトリ](https://github.com/aspnet/AspNetCore)を複製またはダウンロードします。
+* 複製したASP.NET Core リポジトリと一致するバージョンの[.NET Core SDK](https://www.microsoft.com/net/download/all)がインストールされていることを確認します。
+* *AspNetCore/src/Security/samples*以下のサンプルに移動し、`dotnet run`でサンプルを実行します。


### PR DESCRIPTION
- 全体的に：語順を日本語として意味が通るように修正
- 「AspNetCore/src/Security/samples」はフォルダのパスなので翻訳してはいけない
- 「要求」→「クレーム」：認証のコンテキストでの「claims」は一般的に「クレーム」とするのが一般的（"要求"は通常は"request"と解釈されるため区別できなくなる）